### PR TITLE
Typo correction related to Jenkins image file

### DIFF
--- a/errata.md
+++ b/errata.md
@@ -1,13 +1,23 @@
 # Errata for *Book Title*
-
 On **page xx** [Summary of error]:
  
 Details of error here. Highlight key pieces in **bold**.
 
 ***
-
-On **page xx** [Summary of error]:
+On **page 120, 122** [Jenkins Docker image file path correction]:
  
-Details of error here. Highlight key pieces in **bold**.
+The Jenkins Docker image file should be **jenkins/jenkins:lts**. For details of the file, please refer to [https://hub.docker.com/r/jenkins/jenkins/](https://hub.docker.com/r/jenkins/jenkins/).
 
+```
+...
+spec:
+  containers:
+  - name: master
+    image: **jenkins/jenkins:lts**
+```
+***
+***
+On **page 129** [Jenkins username correction]:
+ 
+The actual Jenkins username should be **"jenkins"** instead of "Jenkins".
 ***

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: jenkins/jenkins:tls
+        image: jenkins/jenkins:lts
         ports:
         - containerPort: 8080
         - containerPort: 50000


### PR DESCRIPTION
Jenkins Docker image file should be jenkins/jenkins:lts according to Docker Hub description. Also, the username for login on Jenkins should be "jenkins".